### PR TITLE
Modernize (gradle 3.5, sdk/support 25) and DRY/Cleanup

### DIFF
--- a/android-styled-dialog/build.gradle
+++ b/android-styled-dialog/build.gradle
@@ -1,16 +1,16 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile 'com.android.support:support-v4:24.0.0'
+    compile "com.android.support:support-v4:${project.ext.support_version}"
 }
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    compileSdkVersion project.ext.sdk
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 24
+        minSdkVersion project.ext.minsdk
+        targetSdkVersion project.ext.sdk
     }
 
     compileOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,22 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
+
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+    }
+    project.ext {
+        support_version = "25.3.1"
+        buildToolsVersion = "25.0.2"
+        sdk = 25
+        minsdk = 15
     }
 }
 

--- a/cgcmn-liban/build.gradle
+++ b/cgcmn-liban/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    compileSdkVersion project.ext.sdk
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 24
+        minSdkVersion project.ext.minsdk
+        targetSdkVersion project.ext.sdk
         versionCode 1
         versionName "1.0"
     }
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:24.0.0'
+    compile "com.android.support:support-v4:${project.ext.support_version}"
     compile 'com.squareup.okhttp3:okhttp:3.2.0'
     compile project(':android-styled-dialog')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip

--- a/trezor-app/build.gradle
+++ b/trezor-app/build.gradle
@@ -1,28 +1,13 @@
-//buildscript {
-//    repositories {
-//        maven { url 'https://maven.fabric.io/public' }
-//    }
-//
-//    dependencies {
-//        classpath 'io.fabric.tools:gradle:1.+'
-//    }
-//}
 apply plugin: 'com.android.application'
-//apply plugin: 'io.fabric'
-
-//repositories {
-//    maven { url 'https://maven.fabric.io/public' }
-//}
-
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    compileSdkVersion project.ext.sdk
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "io.trezor.app"
-        minSdkVersion 15
-        targetSdkVersion 24
+        minSdkVersion project.ext.minsdk
+        targetSdkVersion project.ext.sdk
         versionCode 7
         versionName "1.0.3"
         vectorDrawables.useSupportLibrary true
@@ -47,12 +32,12 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:24.0.0'
-    compile 'com.android.support:design:24.0.0'
+
+    compile "com.android.support:support-v4:${project.ext.support_version}"
+    compile "com.android.support:appcompat-v7:${project.ext.support_version}"
+    compile "com.android.support:design:${project.ext.support_version}"
+
     compile project(':trezor-lib')
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha6'
+    compile 'com.android.support.constraint:constraint-layout:1.0.0'
     compile 'com.google.zxing:core:3.2.1'
-//    compile('com.crashlytics.sdk.android:crashlytics:2.6.1@aar') {
-//        transitive = true;
-//    }
 }

--- a/trezor-lib/build.gradle
+++ b/trezor-lib/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    compileSdkVersion project.ext.sdk
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 24
+        minSdkVersion project.ext.minsdk
+        targetSdkVersion project.ext.sdk
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
This is needed so I can use the current AndroidStudio without it yelling at me all the time and we have better build-speeds.
DRY  by using a global project configuration so the diff for such and update is way smaller next time and we do not forget a thing;-)

Also I see that the travis-build is currently broken on master: perhaps you are open to switch to kontinuum:
https://github.com/ligi/kontinuum
Then we will also have archived reports on IPFS ;-)