### PR TITLE
Remove old version reference and add jitpack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # trezor-android
 
-[![Build Status](https://travis-ci.org/trezor/trezor-android.svg?branch=master)](https://travis-ci.org/trezor/trezor-android) [![gitter](https://badges.gitter.im/trezor/community.svg)](https://gitter.im/trezor/community)
+[![Build Status](https://travis-ci.org/trezor/trezor-android.svg?branch=master)](https://travis-ci.org/trezor/trezor-android) [![gitter](https://badges.gitter.im/trezor/community.svg)](https://gitter.im/trezor/community) [![](https://jitpack.io/v/trezor/trezor-android.svg)](https://jitpack.io/#trezor/trezor-android)
 
 TREZOR Management App and Communication Library for Android
 
@@ -27,10 +27,12 @@ Then you can add the dependency like this:
 
 ```groovy
 dependencies {
-    compile 'com.github.trezor.trezor-android:trezor-lib:v1.0.4'
+    compile 'com.github.trezor.trezor-android:trezor-lib:<current_version>'
     ...
 }
 ```
+
+You can see what to best use for ```<current_version>``` in the jitpack badge on the top.
 
 Please consider using [gradle witness](https://github.com/WhisperSystems/gradle-witness) to improve security.
 


### PR DESCRIPTION
The readme was referencing an outdated version. Remove version completely so this does not happen again. Also add jitpack badge so users see latest pushed version very easily. 